### PR TITLE
disable HTTP lib logger. I found out that goroutines end on the loggi…

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 
@@ -89,7 +91,14 @@ func (b *backend) Client(ctx context.Context, s logical.Storage) (*packngo.Clien
 		return b.client, nil
 	}
 
-	b.client = packngo.NewClientWithAuth("Hashicorp Vault", conf.APIToken, nil)
+	httpClient := retryablehttp.NewClient()
+	httpClient.Logger = nil
+
+	httpClient.RetryWaitMin = time.Second
+	httpClient.RetryWaitMax = 30 * time.Second
+	httpClient.RetryMax = 10
+
+	b.client = packngo.NewClientWithAuth("Hashicorp Vault", conf.APIToken, httpClient)
 	return b.client, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/hashicorp/go-hclog v0.12.0
+	github.com/hashicorp/go-retryablehttp v0.6.2
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820


### PR DESCRIPTION
I found out that goroutines quit on the logging calls of go-retryablehttp.

fixes #12 