### PR TITLE
backend: add pathListRoles support

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -37,6 +37,7 @@ func NewBackend(system logical.SystemView) *backend {
 		},
 
 		Paths: []*framework.Path{
+			b.pathListRoles(),
 			b.pathRole(),
 			b.pathConfig(),
 			b.pathCredentials(),

--- a/path_roles.go
+++ b/path_roles.go
@@ -41,7 +41,7 @@ type roleEntry struct {
 
 func (b *backend) pathListRoles() *framework.Path {
 	return &framework.Path{
-		Pattern: "role/?$",
+		Pattern: "roles/?$",
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ListOperation: b.operationRolesList,
 		},


### PR DESCRIPTION
~I haven't actually tested this yet (I'll do that today ... hopefully ...) but I noticed you can't actually enumerate configured roles, but the code was already there.~

This is working:


```
[grahamc@Petunia:~]$ vault list packet/roles
Keys
----
foo
bar
```